### PR TITLE
Feature/hits: 게시물 상세 조회 시 조회수 증가 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ dependencies {
 	// test를 위한 embedded redis
 	testImplementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
 
-	// Test In-Memory-Database
 	runtimeOnly 'com.h2database:h2'
 
 

--- a/src/main/java/toy/board/controller/post/PostController.java
+++ b/src/main/java/toy/board/controller/post/PostController.java
@@ -19,13 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import toy.board.constant.SessionConst;
 import toy.board.controller.post.dto.*;
-import toy.board.exception.BusinessException;
-import toy.board.exception.ExceptionCode;
 import toy.board.repository.comment.CommentRepository;
 import toy.board.repository.post.PostRepository;
 import toy.board.repository.post.dto.PostDto;
 import toy.board.service.comment.CommentService;
 import toy.board.service.post.PostService;
+import toy.board.service.post.dto.PostDetailDto;
 
 @Controller
 @RequestMapping("/posts")
@@ -66,14 +65,9 @@ public class PostController {
 //    } === 필요한가? ===
 
     @GetMapping("/{postId}")
-    public ResponseEntity<Map<String, Object>> getPost(@PathVariable("postId") final Long postId) {
-        HashMap<String, Object> map = new HashMap<>();
-        map.put("postDto",
-                postRepository.getPostDtoById(postId).orElseThrow(
-                        () -> new BusinessException(ExceptionCode.POST_NOT_FOUND)
-                ));
-        map.put("commentDtos", commentRepository.getCommentDtosByPostId(postId));
-        return ResponseEntity.ok(map);
+    public ResponseEntity<PostDetailDto> getPost(@PathVariable("postId") final Long postId) {
+        PostDetailDto postDetail = postService.getPostDetail(postId);
+        return ResponseEntity.ok(postDetail);
     }
 
     // createComment

--- a/src/main/java/toy/board/domain/base/BaseTimeEntity.java
+++ b/src/main/java/toy/board/domain/base/BaseTimeEntity.java
@@ -22,6 +22,6 @@ public class BaseTimeEntity {
     private LocalDateTime lastModifiedDate;
 
     public boolean isModified() {
-        return !createdDate.isEqual(lastModifiedDate);
+        return createdDate != null && !createdDate.isEqual(lastModifiedDate);
     }
 }

--- a/src/main/java/toy/board/domain/post/Post.java
+++ b/src/main/java/toy/board/domain/post/Post.java
@@ -51,7 +51,7 @@ public class Post extends BaseDeleteEntity {
         this.hits = 0L;
     }
 
-    public void update(@NotBlank final String content, final Long writerId) {
+    public void update(@NotBlank final String content, @NotNull final Long writerId) {
         validateRight(writerId);
         this.content = content;
     }

--- a/src/main/java/toy/board/repository/comment/CommentQueryRepository.java
+++ b/src/main/java/toy/board/repository/comment/CommentQueryRepository.java
@@ -1,9 +1,8 @@
 package toy.board.repository.comment;
 
-import java.util.List;
-import toy.board.repository.comment.dto.CommentDto;
+import toy.board.repository.comment.dto.CommentListDto;
 
 public interface CommentQueryRepository {
 
-    List<CommentDto> getCommentDtosByPostId(Long postId);
+    CommentListDto getCommentListDtoByPostId(Long postId);
 }

--- a/src/main/java/toy/board/repository/comment/CommentRepositoryImpl.java
+++ b/src/main/java/toy/board/repository/comment/CommentRepositoryImpl.java
@@ -8,6 +8,7 @@ import toy.board.repository.comment.dto.CommentDto;
 import toy.board.domain.post.Comment;
 import toy.board.domain.post.CommentType;
 import toy.board.domain.post.QComment;
+import toy.board.repository.comment.dto.CommentListDto;
 import toy.board.repository.support.Querydsl4RepositorySupport;
 
 public class CommentRepositoryImpl extends Querydsl4RepositorySupport
@@ -18,8 +19,13 @@ public class CommentRepositoryImpl extends Querydsl4RepositorySupport
     }
 
     @Override
-    public List<CommentDto> getCommentDtosByPostId(final Long postId) {
-        return getComments(postId).stream().map(this::convertToDto).toList();
+    public CommentListDto getCommentListDtoByPostId(final Long postId) {
+        return new CommentListDto(
+                getComments(postId)
+                        .stream()
+                        .map(this::convertToDto)
+                        .toList()
+        );
     }
 
     private List<Comment> getComments(final Long postId) {

--- a/src/main/java/toy/board/repository/comment/dto/CommentListDto.java
+++ b/src/main/java/toy/board/repository/comment/dto/CommentListDto.java
@@ -1,0 +1,18 @@
+package toy.board.repository.comment.dto;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+public record CommentListDto(
+        List<CommentDto> commentDtos
+) {
+    public long getTotalCommentNum() {
+        AtomicLong commentNum = new AtomicLong(commentDtos.size());
+
+        commentDtos.forEach(c ->
+            commentNum.addAndGet(c.replies().size())
+        );
+
+        return commentNum.get();
+    }
+}

--- a/src/main/java/toy/board/repository/post/dto/PostDto.java
+++ b/src/main/java/toy/board/repository/post/dto/PostDto.java
@@ -1,6 +1,10 @@
 package toy.board.repository.post.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import toy.board.domain.post.Post;
+import toy.board.repository.comment.dto.CommentDto;
 
 public record PostDto(
         Long postId,
@@ -13,4 +17,23 @@ public record PostDto(
         boolean isModified,
         Long commentNum
 ) {
+    public static PostDto of(Post post, List<CommentDto> commentDtos) {
+        AtomicLong commentNum = new AtomicLong(commentDtos.size());
+
+        commentDtos.forEach(c ->
+                commentNum.addAndGet(c.replies().size())
+        );
+
+        return new PostDto(
+                post.getId(),
+                post.getWriterId(),
+                post.getWriter(),
+                post.getTitle(),
+                post.getContent(),
+                post.getHits(),
+                post.getCreatedDate(),
+                post.isModified(),
+                commentNum.get()
+        );
+    }
 }

--- a/src/main/java/toy/board/repository/post/dto/PostDto.java
+++ b/src/main/java/toy/board/repository/post/dto/PostDto.java
@@ -1,10 +1,7 @@
 package toy.board.repository.post.dto;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 import toy.board.domain.post.Post;
-import toy.board.repository.comment.dto.CommentDto;
 
 public record PostDto(
         Long postId,
@@ -17,13 +14,7 @@ public record PostDto(
         boolean isModified,
         Long commentNum
 ) {
-    public static PostDto of(Post post, List<CommentDto> commentDtos) {
-        AtomicLong commentNum = new AtomicLong(commentDtos.size());
-
-        commentDtos.forEach(c ->
-                commentNum.addAndGet(c.replies().size())
-        );
-
+    public static PostDto of(Post post, long commentNum) {
         return new PostDto(
                 post.getId(),
                 post.getWriterId(),
@@ -33,7 +24,7 @@ public record PostDto(
                 post.getHits(),
                 post.getCreatedDate(),
                 post.isModified(),
-                commentNum.get()
+                commentNum
         );
     }
 }

--- a/src/main/java/toy/board/service/post/PostService.java
+++ b/src/main/java/toy/board/service/post/PostService.java
@@ -1,16 +1,14 @@
 package toy.board.service.post;
 
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
 import org.springframework.transaction.annotation.Transactional;
 import toy.board.domain.post.Post;
 import toy.board.exception.BusinessException;
 import toy.board.exception.ExceptionCode;
 import toy.board.repository.comment.CommentRepository;
-import toy.board.repository.comment.dto.CommentDto;
+import toy.board.repository.comment.dto.CommentListDto;
 import toy.board.repository.post.PostRepository;
 import toy.board.repository.post.dto.PostDto;
 import toy.board.repository.profile.ProfileRepository;
@@ -41,11 +39,11 @@ public class PostService {
 
         post.increaseHits();
 
-        List<CommentDto> commentDtos = commentRepository.getCommentDtosByPostId(postId);
+        CommentListDto commentListDto = commentRepository.getCommentListDtoByPostId(postId);
 
-        PostDto postDto = PostDto.of(post, commentDtos);
+        PostDto postDto = PostDto.of(post, commentListDto.getTotalCommentNum());
 
-        return PostDetailDto.of(postDto, commentDtos);
+        return PostDetailDto.of(postDto, commentListDto);
     }
 
     @Transactional

--- a/src/main/java/toy/board/service/post/PostService.java
+++ b/src/main/java/toy/board/service/post/PostService.java
@@ -53,8 +53,8 @@ public class PostService {
         String nickname = profileRepository.findNicknameByMemberId(memberId)
                 .orElseThrow(() -> new BusinessException(ExceptionCode.ACCOUNT_NOT_FOUND));
         Post post = new Post(memberId, nickname, title, content);
-        postRepository.save(post);
-        return post.getId();
+        Post savedPost = postRepository.save(post);
+        return savedPost.getId();
     }
 
     @Transactional

--- a/src/main/java/toy/board/service/post/PostService.java
+++ b/src/main/java/toy/board/service/post/PostService.java
@@ -1,5 +1,6 @@
 package toy.board.service.post;
 
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,8 +10,11 @@ import toy.board.domain.post.Post;
 import toy.board.exception.BusinessException;
 import toy.board.exception.ExceptionCode;
 import toy.board.repository.comment.CommentRepository;
+import toy.board.repository.comment.dto.CommentDto;
 import toy.board.repository.post.PostRepository;
+import toy.board.repository.post.dto.PostDto;
 import toy.board.repository.profile.ProfileRepository;
+import toy.board.service.post.dto.PostDetailDto;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,6 +31,21 @@ public class PostService {
                 .orElseThrow(() -> new BusinessException(ExceptionCode.POST_NOT_FOUND));
         post.update(content, memberId);
         return post.getId();
+    }
+
+    @Transactional
+    public PostDetailDto getPostDetail(final Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new BusinessException(ExceptionCode.POST_NOT_FOUND)
+        );
+
+        post.increaseHits();
+
+        List<CommentDto> commentDtos = commentRepository.getCommentDtosByPostId(postId);
+
+        PostDto postDto = PostDto.of(post, commentDtos);
+
+        return PostDetailDto.of(postDto, commentDtos);
     }
 
     @Transactional

--- a/src/main/java/toy/board/service/post/dto/PostDetailDto.java
+++ b/src/main/java/toy/board/service/post/dto/PostDetailDto.java
@@ -1,0 +1,19 @@
+package toy.board.service.post.dto;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import toy.board.repository.comment.dto.CommentDto;
+import toy.board.repository.post.dto.PostDto;
+
+public record PostDetailDto(
+        Map<String, Object> postDetail
+) {
+
+    public static PostDetailDto of(PostDto postDto, List<CommentDto> commentDtos) {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("post", postDto);
+        map.put("comments", commentDtos);
+        return new PostDetailDto(map);
+    }
+}

--- a/src/main/java/toy/board/service/post/dto/PostDetailDto.java
+++ b/src/main/java/toy/board/service/post/dto/PostDetailDto.java
@@ -1,19 +1,18 @@
 package toy.board.service.post.dto;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import toy.board.repository.comment.dto.CommentDto;
+import toy.board.repository.comment.dto.CommentListDto;
 import toy.board.repository.post.dto.PostDto;
 
 public record PostDetailDto(
         Map<String, Object> postDetail
 ) {
 
-    public static PostDetailDto of(PostDto postDto, List<CommentDto> commentDtos) {
+    public static PostDetailDto of(PostDto postDto, CommentListDto commentListDto) {
         HashMap<String, Object> map = new HashMap<>();
         map.put("post", postDto);
-        map.put("comments", commentDtos);
+        map.put("comments", commentListDto.commentDtos());
         return new PostDetailDto(map);
     }
 }

--- a/src/test/java/toy/board/domain/post/PostTest.java
+++ b/src/test/java/toy/board/domain/post/PostTest.java
@@ -1,22 +1,42 @@
 package toy.board.domain.post;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import toy.board.exception.BusinessException;
+import toy.board.exception.ExceptionCode;
 
 class PostTest {
 
-    @DisplayName("")
+    @DisplayName("권한 없는 사용자가 게시물을 수정하려 할 경우 예외 발생")
     @Test
-    public void notNull() throws Exception {
-
-
+    public void whenUpdatePostWithNotValidWriterId_thenThrowException() throws Exception {
         //given
-
+        Post post = create();
+        String newContent = "new";
         //when
-
+        Long invalidWriterId = post.getWriterId() + 1;
         //then
+        assertThrows(BusinessException.class,
+                () -> post.update(newContent, invalidWriterId),
+                ExceptionCode.POST_NOT_WRITER.getDescription());
     }
 
+    @DisplayName("사용자에 의한 게시물 수정 성공")
+    @Test
+    public void whenUpdatePostWithValidWriterId_thenSuccess() throws Exception {
+        //given
+        Post post = create();
+        String newContent = "new";
+        Long writerId = post.getWriterId();
+        //when
+        post.update(newContent, writerId);
+        //then
+        assertThat(post.getContent()).isEqualTo(newContent);
+    }
     public static Post create() {
         return new Post(1L, "writer", "title", "content");
     }

--- a/src/test/java/toy/board/repository/comment/CommentRepositoryImplTest.java
+++ b/src/test/java/toy/board/repository/comment/CommentRepositoryImplTest.java
@@ -18,6 +18,7 @@ import toy.board.domain.user.LoginType;
 import toy.board.domain.user.Member;
 import toy.board.domain.user.Profile;
 import toy.board.domain.user.UserRole;
+import toy.board.repository.comment.dto.CommentListDto;
 
 @SpringBootTest
 class CommentRepositoryImplTest {
@@ -54,12 +55,10 @@ class CommentRepositoryImplTest {
         em.clear();
 
         //when
-        List<CommentDto> comments = commentRepository.getCommentDtosByPostId(post.getId());
+        CommentListDto commentListDto = commentRepository.getCommentListDtoByPostId(post.getId());
 
         //then
-        assertThat(comments.size()).isEqualTo(0);
-        Assertions.assertThrows(ArrayIndexOutOfBoundsException.class,
-                () -> comments.get(0));
+        assertThat(commentListDto.getTotalCommentNum()).isEqualTo(0);
     }
 
 }

--- a/src/test/java/toy/board/service/post/PostServiceTest.java
+++ b/src/test/java/toy/board/service/post/PostServiceTest.java
@@ -1,66 +1,102 @@
 package toy.board.service.post;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 
-import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import toy.board.domain.post.Post;
 import toy.board.domain.user.Member;
 import toy.board.domain.user.MemberTest;
 import toy.board.exception.BusinessException;
 import toy.board.exception.ExceptionCode;
-import toy.board.service.post.PostService;
+import toy.board.repository.comment.CommentRepository;
+import toy.board.repository.post.PostRepository;
+import toy.board.repository.profile.ProfileRepository;
 
-@SpringBootTest
-@Transactional
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)   // 사용하지 않는 Mock 설정에 대해 오류를 발생하지 않도록 설정
 class PostServiceTest {
 
-    @Autowired
+    @InjectMocks
     private PostService postService;
-    @Autowired
-    private EntityManager em;
 
-    private Long memberId;
-    private String content = "content";
-    private String title = "title";
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private ProfileRepository profileRepository;
 
     Long invalidPostId = 1242L;
     Long invalidMemberId = 23523L;
+    String newContent = "new content";
+    String content = "content";
+    String title = "title";
+    Long postId = 1L;
+    Long memberId = 1L;
 
     @BeforeEach
     void init() {
         Member member = MemberTest.create();
-        em.persist(member);
-        memberId = member.getId();
-        em.flush(); em.clear();
+        Post post = new Post(memberId, member.getUsername(), title, content);
+
+        given(postRepository.findById(anyLong())).willReturn(Optional.empty());
+        given(postRepository.findById(eq(postId))).willReturn(Optional.of(post));
+        given(commentRepository.getCommentDtosByPostId(postId)).willReturn(new ArrayList<>());
+
+        given(profileRepository.findNicknameByMemberId(anyLong())).willReturn(
+                Optional.empty());
+        given(profileRepository.findNicknameByMemberId(eq(memberId))).willReturn(
+                Optional.of(member.getProfile().getNickname()));
+    }
+
+    @DisplayName("게시물 조회 시 게시물 조회 수 증가: 성공")
+    @Test
+    public void whenReadPostDetail_thenIncreasePostHits() throws  Exception {
+        //given
+        Long expectedHits = 1L;
+
+        //when
+        postService.getPostDetail(postId);
+        Post post = postRepository.findById(postId).get();
+
+        //then
+        assertThat(post.getHits()).isEqualTo(expectedHits);
     }
 
     @DisplayName("update 성공 시 update post id 반환")
     @Test
     public void whenPostUpdate_thenReturnValidValue() throws  Exception {
         //given
-        Long postId = postService.create(title, content, memberId);
         //when
+        postService.update(newContent, postId, memberId);
+        Post post = postRepository.findById(postId).get();
         //then
-        Long updatedPostId = postService.update(content, postId, memberId);
-        assertThat(updatedPostId).isEqualTo(postId);
+        assertThat(post.getContent()).isEqualTo(newContent);
     }
 
     @DisplayName("update 시 유효하지 않은 post id 사용하면 예외 발생")
     @Test
     public void whenPostUpdateWithInvalidPostId_thenThrowException() throws  Exception {
         //given
-        Long postId = postService.create(title, content, memberId);
         //when
         //then
         BusinessException e = assertThrows(BusinessException.class,
-                () -> postService.update(content, invalidPostId, memberId));
+                () -> postService.update(newContent, invalidPostId, memberId));
         assertThat(e.getCode()).isEqualTo(ExceptionCode.POST_NOT_FOUND);
     }
 
@@ -68,25 +104,11 @@ class PostServiceTest {
     @Test
     public void whenPostUpdateWithInvalidMemberId_thenThrowException() throws  Exception {
         //given
-        Long postId = postService.create(title, content, memberId);
         //when
         //then
         BusinessException e = assertThrows(BusinessException.class,
-                () -> postService.update(content, postId, invalidMemberId));
+                () -> postService.update(newContent, postId, invalidMemberId));
         assertThat(e.getCode()).isEqualTo(ExceptionCode.POST_NOT_WRITER);
-    }
-
-    @DisplayName("post create의 반환값이 정상적으로 반환됨")
-    @Test
-    public void whenCreatePost_thenReturnValidValue() throws Exception {
-        //given
-        Long postId = postService.create(title, content, memberId);
-        //when
-        Post post = em.find(Post.class, postId);
-        //then
-        System.out.println("postId = " + postId);
-        assertThat(postId).isNotNull();
-        assertThat(postId).isEqualTo(post.getId());
     }
 
     @DisplayName("post create 시 유효하지 않은 member id 사용하면 예외 발생")
@@ -99,23 +121,11 @@ class PostServiceTest {
                 () -> postService.create(title, content, invalidMemberId));
         assertThat(e.getCode()).isEqualTo(ExceptionCode.ACCOUNT_NOT_FOUND);
     }
-
-    @DisplayName("post 정상 삭제")
-    @Test
-    public void PostServiceTest() throws  Exception {
-        //given
-        Long postId = postService.create(title, content, memberId);
-        //when
-        postService.delete(postId, memberId);
-        //then
-        assertThat(em.find(Post.class, postId)).isNull();
-    }
     
     @DisplayName("post 삭제 시 유효하지 않은 postId 사용하면 예외 발생")
     @Test
     public void whenDeletePostWithInvalidPostId_thenThrowsException() throws  Exception {
         //given
-        Long postId = postService.create(title, content, memberId);
         //when
         //then
         BusinessException e = assertThrows(BusinessException.class,
@@ -127,7 +137,6 @@ class PostServiceTest {
     @Test
     public void whenDeletePostWithInvalidMemberId_thenThrowsException() throws  Exception {
         //given
-        Long postId = postService.create(title, content, memberId);
         //when
         //then
         BusinessException e = assertThrows(BusinessException.class,

--- a/src/test/java/toy/board/service/post/PostServiceTest.java
+++ b/src/test/java/toy/board/service/post/PostServiceTest.java
@@ -24,6 +24,7 @@ import toy.board.domain.user.MemberTest;
 import toy.board.exception.BusinessException;
 import toy.board.exception.ExceptionCode;
 import toy.board.repository.comment.CommentRepository;
+import toy.board.repository.comment.dto.CommentListDto;
 import toy.board.repository.post.PostRepository;
 import toy.board.repository.profile.ProfileRepository;
 
@@ -53,10 +54,11 @@ class PostServiceTest {
     void init() {
         Member member = MemberTest.create();
         Post post = new Post(memberId, member.getUsername(), title, content);
+        CommentListDto commentListDto = new CommentListDto(new ArrayList<>());
 
         given(postRepository.findById(anyLong())).willReturn(Optional.empty());
         given(postRepository.findById(eq(postId))).willReturn(Optional.of(post));
-        given(commentRepository.getCommentDtosByPostId(postId)).willReturn(new ArrayList<>());
+        given(commentRepository.getCommentListDtoByPostId(postId)).willReturn(commentListDto);
 
         given(profileRepository.findNicknameByMemberId(anyLong())).willReturn(
                 Optional.empty());

--- a/src/test/java/toy/board/service/user/MemberServiceTest.java
+++ b/src/test/java/toy/board/service/user/MemberServiceTest.java
@@ -65,7 +65,7 @@ class MemberServiceTest {
         given(passwordEncoder.encode(anyString())).willReturn(password);
     }
 
-    @DisplayName("입력한 아이디와 일치하는 멤버가 없음")
+    @DisplayName("입력한 아이디와 일치하는 멤버가 없을 때 throw exception")
     @Test
     public void login_member_no_exist_test() throws Exception {
         Optional<Member> findMember = Optional.ofNullable(null);
@@ -76,7 +76,7 @@ class MemberServiceTest {
                 () -> memberService.login(username, password));
     }
 
-    @DisplayName("멤버의 로그인 타입이 로컬로그인이 아님")
+    @DisplayName("멤버의 로그인 타입이 로컬로그인이 아닐 때 throw exception")
     @Test
     public void login_not_match_member_login_type() throws Exception {
         Member findMember = createMember(LoginType.SOCIAL_LOGIN);
@@ -89,7 +89,7 @@ class MemberServiceTest {
         assertThrows(BusinessException.class, () -> memberService.login(username, password));
     }
 
-    @DisplayName("패스워드 불일치")
+    @DisplayName("패스워드 불일치 시 throw exception")
     @Test
     public void not_match_password() throws  Exception {
         Member findMember = createMember(LoginType.LOCAL_LOGIN);
@@ -113,9 +113,6 @@ class MemberServiceTest {
         member.changeLogin(login);
         return member;
     }
-
-    // join
-    // - 중복 검사가 잘 이루어지는가
 
     @DisplayName("이메일과 닉네임이 모두 기존에 존재하지 않음: 통과")
     @Test


### PR DESCRIPTION
#변경사항

- PostController에서 수행하던 게시물 상세 조회를 로직이 복잡해짐에 따라 PostService로 위임
- PostService.getPostDetail() 구현
- List<CommentDto> -> CommentListDto: 기존의 리스트 형식의 CommentDto를 일급 컬렉션으로 만들고, 관련 메서드를 포함하도록 함.