### PR TITLE
Feature/join

### DIFF
--- a/src/main/java/toy/board/domain/post/Comment.java
+++ b/src/main/java/toy/board/domain/post/Comment.java
@@ -1,13 +1,26 @@
 package toy.board.domain.post;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
-
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import toy.board.domain.base.BaseDeleteEntity;
+import toy.board.domain.user.Member;
 import toy.board.exception.BusinessException;
 import toy.board.exception.ExceptionCode;
 
@@ -36,11 +49,9 @@ public class Comment extends BaseDeleteEntity {
     @JoinColumn(name = "post_id", nullable = false, updatable = false)
     private Post post;
 
-    @Column(name = "writer_id")
-    private Long writerId;
-
-    @Column(name = "writer")
-    private String writer;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer")
+    private Member writer;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "parent", orphanRemoval = true)
     private List<Comment> replies = new ArrayList<>();
@@ -52,14 +63,12 @@ public class Comment extends BaseDeleteEntity {
 
     public Comment(
             @NotNull final Post post,
-            @NotNull final Long writerId,
-            @NotBlank final String writer,
+            @NotBlank final Member writer,
             @NotNull final String content,
             @NotNull final CommentType type,
             final Comment parent
     ) {
         this.post = post;
-        this.writerId = writerId;
         this.writer = writer;
         this.content = content;
         this.type = type;
@@ -71,13 +80,13 @@ public class Comment extends BaseDeleteEntity {
         }
     }
 
-    public void update(@NotBlank final String content, final Long writerId) {
+    public void update(@NotBlank final String content, @NotNull final Long writerId) {
         validateRight(writerId);
         this.content = content;
     }
 
     public void validateRight(final Long writerId) {
-        if (!writerId.equals(this.writerId)) {
+        if (!writerId.equals(this.writer.getId())) {
             throw new BusinessException(ExceptionCode.COMMENT_NOT_WRITER);
         }
     }

--- a/src/main/java/toy/board/domain/post/Post.java
+++ b/src/main/java/toy/board/domain/post/Post.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import toy.board.domain.base.BaseDeleteEntity;
+import toy.board.domain.user.Member;
+import toy.board.domain.user.Profile;
 import toy.board.exception.BusinessException;
 import toy.board.exception.ExceptionCode;
 
@@ -31,38 +33,47 @@ public class Post extends BaseDeleteEntity {
     @Column(name = "hits", nullable = false)
     private Long hits;
 
-    @Column(name = "writer_id")
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
+    private Member writer;
 
-    @Column(name = "writer")
-    private String writer;
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "writer")
+//    private Profile writer;
 
     public Post(
-            @NotNull final Long writerId,
-            @NotNull final String writer,
+//            @NotNull final Member writerId,
+            @NotNull final Member writer,
             @NotBlank final String title,
             @NotBlank final String content
     ) {
 
-        this.writerId = writerId;
         this.writer = writer;
         this.title = title;
         this.content = content;
         this.hits = 0L;
     }
 
-    public void update(@NotBlank final String content, @NotNull final Long writerId) {
-        validateRight(writerId);
+    public void update(@NotBlank final String content, @NotNull final Long writer) {
+        validateRight(writer);
         this.content = content;
     }
 
-    public void validateRight(final Long writerId) {
-        if (!writerId.equals(this.writerId)) {
+    public void validateRight(final Long writer) {
+        if (!writer.equals(this.writer.getId())) {
             throw new BusinessException(ExceptionCode.POST_NOT_WRITER);
         }
     }
 
     public long increaseHits() {
         return this.hits++;
+    }
+
+    public Long getWriterId() {
+        return this.writer.getId();
+    }
+
+    public String getWriterNickname() {
+        return this.writer.getProfile().getNickname();
     }
 }

--- a/src/main/java/toy/board/repository/comment/CommentRepositoryImpl.java
+++ b/src/main/java/toy/board/repository/comment/CommentRepositoryImpl.java
@@ -4,10 +4,10 @@ import static toy.board.domain.post.QComment.comment;
 
 import java.util.Comparator;
 import java.util.List;
-import toy.board.repository.comment.dto.CommentDto;
 import toy.board.domain.post.Comment;
 import toy.board.domain.post.CommentType;
 import toy.board.domain.post.QComment;
+import toy.board.repository.comment.dto.CommentDto;
 import toy.board.repository.comment.dto.CommentListDto;
 import toy.board.repository.support.Querydsl4RepositorySupport;
 
@@ -41,10 +41,10 @@ public class CommentRepositoryImpl extends Querydsl4RepositorySupport
     }
 
     private CommentDto convertToDto(final Comment comment) {
-        CommentDto commentDto = new CommentDto(
+        return new CommentDto(
                 comment.getId(),
-                comment.getWriterId(),
-                comment.getWriter(),
+                comment.getWriter().getId(),
+                comment.getWriter().getProfile().getNickname(),
                 comment.getContent(),
                 comment.getType(),
                 comment.isDeleted(),
@@ -55,8 +55,8 @@ public class CommentRepositoryImpl extends Querydsl4RepositorySupport
                 ).map(reply ->
                         new CommentDto(
                                 reply.getId(),
-                                reply.getWriterId(),
-                                reply.getWriter(),
+                                reply.getWriter().getId(),
+                                reply.getWriter().getProfile().getNickname(),
                                 reply.getContent(),
                                 reply.getType(),
                                 reply.isDeleted(),
@@ -65,6 +65,5 @@ public class CommentRepositoryImpl extends Querydsl4RepositorySupport
                                 null)
                 ).toList()
         );
-        return commentDto;
     }
 }

--- a/src/main/java/toy/board/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/toy/board/repository/post/PostRepositoryImpl.java
@@ -2,6 +2,8 @@ package toy.board.repository.post;
 
 import static toy.board.domain.post.QComment.comment;
 import static toy.board.domain.post.QPost.post;
+import static toy.board.domain.user.QMember.*;
+import static toy.board.domain.user.QProfile.*;
 
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
@@ -9,6 +11,8 @@ import com.querydsl.core.types.dsl.CaseBuilder;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import toy.board.domain.user.QMember;
+import toy.board.domain.user.QProfile;
 import toy.board.repository.post.dto.PostDto;
 import toy.board.domain.post.Post;
 import toy.board.repository.support.Querydsl4RepositorySupport;
@@ -52,8 +56,8 @@ public class PostRepositoryImpl extends Querydsl4RepositorySupport
     private ConstructorExpression<PostDto> getPostDtoConstructorExpression() {
         return Projections.constructor(PostDto.class,
                 post.id.as("postId"),
-                post.writerId,
-                post.writer,
+                post.writer.id,
+                post.writer.profile.nickname,
                 post.title,
                 post.content,
                 post.hits,

--- a/src/main/java/toy/board/repository/post/dto/PostDto.java
+++ b/src/main/java/toy/board/repository/post/dto/PostDto.java
@@ -18,7 +18,7 @@ public record PostDto(
         return new PostDto(
                 post.getId(),
                 post.getWriterId(),
-                post.getWriter(),
+                post.getWriterNickname(),
                 post.getTitle(),
                 post.getContent(),
                 post.getHits(),

--- a/src/main/java/toy/board/repository/user/MemberRepository.java
+++ b/src/main/java/toy/board/repository/user/MemberRepository.java
@@ -10,7 +10,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberQue
 
     Optional<Member> findMemberByUsername(String username);
 
-    Optional<Member> findMemberById(Long id);
+    @Query(value = "SELECT m FROM Member m Join Fetch m.profile WHERE m.id = :memberId")
+    Optional<Member> findMemberById(@Param("memberId")Long id);
 
     @Query("select m from Member m where m.profile.nickname = :nickname")
     Optional<Member> findMemberByNickname(@Param("nickname")String nickname);

--- a/src/main/java/toy/board/service/comment/CommentService.java
+++ b/src/main/java/toy/board/service/comment/CommentService.java
@@ -8,11 +8,12 @@ import org.springframework.transaction.annotation.Transactional;
 import toy.board.domain.post.Comment;
 import toy.board.domain.post.CommentType;
 import toy.board.domain.post.Post;
+import toy.board.domain.user.Member;
 import toy.board.exception.BusinessException;
 import toy.board.exception.ExceptionCode;
 import toy.board.repository.comment.CommentRepository;
 import toy.board.repository.post.PostRepository;
-import toy.board.repository.profile.ProfileRepository;
+import toy.board.repository.user.MemberRepository;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,7 +21,7 @@ import toy.board.repository.profile.ProfileRepository;
 public class CommentService {
 
     private final CommentRepository commentRepository;
-    private final ProfileRepository profileRepository;
+    private final MemberRepository memberRepository;
     private final PostRepository postRepository;
 
     @Transactional
@@ -28,14 +29,14 @@ public class CommentService {
             final Optional<Long> parentId, final Long postId, final Long memberId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BusinessException(ExceptionCode.POST_NOT_FOUND));
-        String nickname = profileRepository.findNicknameByMemberId(memberId)
+        Member member = memberRepository.findMemberById(memberId)
                 .orElseThrow(() -> new BusinessException(ExceptionCode.ACCOUNT_NOT_FOUND));
         Comment parentComment = parentId.map(p ->
                 commentRepository.findById(p)
                         .orElseThrow(() -> new BusinessException(ExceptionCode.COMMENT_NOT_FOUND))
         ).orElse(null);
 
-        Comment comment = new Comment(post, memberId, nickname, content, type, parentComment);
+        Comment comment = new Comment(post, member, content, type, parentComment);
 
         commentRepository.save(comment);
         return comment.getId();

--- a/src/main/java/toy/board/service/post/PostService.java
+++ b/src/main/java/toy/board/service/post/PostService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import toy.board.domain.post.Post;
+import toy.board.domain.user.Member;
 import toy.board.exception.BusinessException;
 import toy.board.exception.ExceptionCode;
 import toy.board.repository.comment.CommentRepository;
@@ -12,6 +13,7 @@ import toy.board.repository.comment.dto.CommentListDto;
 import toy.board.repository.post.PostRepository;
 import toy.board.repository.post.dto.PostDto;
 import toy.board.repository.profile.ProfileRepository;
+import toy.board.repository.user.MemberRepository;
 import toy.board.service.post.dto.PostDetailDto;
 
 @Service
@@ -19,8 +21,9 @@ import toy.board.service.post.dto.PostDetailDto;
 @Transactional(readOnly = true)
 public class PostService {
 
-    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
     private final ProfileRepository profileRepository;
+    private final PostRepository postRepository;
     private final CommentRepository commentRepository;
 
     @Transactional
@@ -33,9 +36,8 @@ public class PostService {
 
     @Transactional
     public PostDetailDto getPostDetail(final Long postId) {
-        Post post = postRepository.findById(postId).orElseThrow(
-                () -> new BusinessException(ExceptionCode.POST_NOT_FOUND)
-        );
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new BusinessException(ExceptionCode.POST_NOT_FOUND));
 
         post.increaseHits();
 
@@ -48,9 +50,10 @@ public class PostService {
 
     @Transactional
     public Long create(final String title, final String content, final Long memberId) {
-        String nickname = profileRepository.findNicknameByMemberId(memberId)
+        Member findMember = memberRepository.findMemberById(memberId)
                 .orElseThrow(() -> new BusinessException(ExceptionCode.ACCOUNT_NOT_FOUND));
-        Post post = new Post(memberId, nickname, title, content);
+
+        Post post = new Post(findMember, title, content);
         Post savedPost = postRepository.save(post);
         return savedPost.getId();
     }

--- a/src/test/java/toy/board/controller/post/PostControllerTest.java
+++ b/src/test/java/toy/board/controller/post/PostControllerTest.java
@@ -1,7 +1,5 @@
 package toy.board.controller.post;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
@@ -31,7 +29,11 @@ import toy.board.domain.auth.Login;
 import toy.board.domain.post.Comment;
 import toy.board.domain.post.CommentType;
 import toy.board.domain.post.Post;
-import toy.board.domain.user.*;
+import toy.board.domain.user.LoginType;
+import toy.board.domain.user.Member;
+import toy.board.domain.user.MemberTest;
+import toy.board.domain.user.Profile;
+import toy.board.domain.user.UserRole;
 
 @Transactional
 @ExtendWith(MockitoExtension.class) // Mockito와 같은 확장 기능을 테스트에 통합시켜주는 어노테이션
@@ -489,8 +491,8 @@ class PostControllerTest {
         //given
         Long postId = this.postId;
         Post post = em.find(Post.class, postId);
-        Long memberId = post.getWriterId();
-        session.setAttribute(SessionConst.LOGIN_MEMBER, memberId);
+        Long writerId = post.getWriterId();
+        session.setAttribute(SessionConst.LOGIN_MEMBER, writerId);
         //when
         PostUpdateDto request = new PostUpdateDto("content");
         String content = mapper.writeValueAsString(request);
@@ -938,7 +940,7 @@ class PostControllerTest {
         em.persist(member2);
 
         for (int i = 0; i < 30; i++) {
-            Post post = new Post(member.getId(), member.getProfile().getNickname(),
+            Post post = new Post(member,
                     "title" + i,
                     "content" + i
             );
@@ -952,8 +954,7 @@ class PostControllerTest {
             for (int k = 0; k < 3; k++) {
                 Comment comment = new Comment(
                         post,
-                        member.getId(),
-                        member.getProfile().getNickname(),
+                        member,
                         "comment" + String.valueOf(k),
                         CommentType.COMMENT,
                         null
@@ -967,8 +968,7 @@ class PostControllerTest {
                 for (int j = 0; j < 5; j++) {
                     Comment reply = new Comment(
                             post,
-                            member2.getId(),
-                            member2.getProfile().getNickname(),
+                            member2,
                             "reply" + String.valueOf(j),
                             CommentType.REPLY,
                             comment

--- a/src/test/java/toy/board/domain/post/CommentTest.java
+++ b/src/test/java/toy/board/domain/post/CommentTest.java
@@ -1,15 +1,16 @@
 package toy.board.domain.post;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import toy.board.domain.user.Member;
-import toy.board.domain.user.MemberTest;
+import toy.board.exception.BusinessException;
 
 @SpringBootTest
 @Transactional
@@ -18,36 +19,62 @@ class CommentTest {
     @Autowired
     private EntityManager em;
 
+    @DisplayName("권한 검증 성공")
+    @Test
+    public void whenValidateWithMemberId_thenValidateSuccess() throws  Exception {
+        //given
+        Comment comment = create();
+        Post post = comment.getPost();
+        Member member = comment.getWriter();
+
+        em.persist(member);
+        em.persist(post);
+        em.persist(comment);
+
+        long memberId = member.getId();
+
+        //when
+
+        //then
+        Assertions.assertThrows(BusinessException.class, () -> comment.validateRight(memberId));
+    }
+
+    @DisplayName("권한 검증 실패")
+    @Test
+    public void whenValidateWithInvalidMemberId_thenValidateFail() throws  Exception {
+        //given
+        Comment comment = create();
+        Post post = comment.getPost();
+        Member member = comment.getWriter();
+
+        em.persist(member);
+        em.persist(post);
+        em.persist(comment);
+
+        long invalidMemberId = member.getId() + 1;
+
+        //when
+
+        //then
+        Assertions.assertThrows(BusinessException.class, () -> comment.validateRight(invalidMemberId));
+    }
+
     @DisplayName("orphanRemoval test - comment의 필드멤버 reply에 orphanRemoval 설정하면 comment가 삭제될 때만 reply를 삭제하는 단방향 전파가 성립된다. 이는 cascade도 마찬가지이다")
     @Test
     public void post_and_comment_with_no_cascade() throws Exception {
         //given
-        Member member = MemberTest.create();
-        Post post = new Post(
-                member.getId(),
-                member.getProfile().getNickname(),
-                "title",
-                "content"
-        );
+        Comment comment = create();
+        Post post = comment.getPost();
+        Member member = comment.getWriter();
+
         em.persist(member);
-
-        Comment comment = new Comment(
-                post,
-                member.getId(),
-                member.getProfile().getNickname(),
-                "content",
-                CommentType.COMMENT,
-                null
-        );
-
         em.persist(post);
         em.persist(comment);
 
         Comment parentComment = em.find(Comment.class, comment.getId());
         Comment reply = new Comment(
                 post,
-                member.getId(),
-                member.getProfile().getNickname(),
+                member,
                 "content",
                 CommentType.REPLY,
                 parentComment
@@ -67,21 +94,34 @@ class CommentTest {
         assertThat(findComment).isNotNull();
     }
 
+    private static Comment create() {
+        Post post = PostTest.create();
+        return new Comment(
+                post,
+                post.getWriter(),
+                "content",
+                CommentType.COMMENT,
+                null
+        );
+    }
+
 
     @DisplayName("타입에 따른 생성자 구분으로 자동 양방향 매핑")
     @Test
     public void CommentTypeTest() throws  Exception {
         //given
         Post post = PostTest.create();
+        em.persist(post.getWriter());
+        em.persist(post);
         String content = "content";
-        long memberId = 1L;
+
         //when
         CommentType commentType = CommentType.COMMENT;
         CommentType replyType = CommentType.REPLY;
 
         //then
-        Comment parent = new Comment(post, memberId, post.getWriter(), content, commentType, null);
-        Comment reply = new Comment(post, memberId, post.getWriter(), content, replyType, parent);
+        Comment parent = new Comment(post, post.getWriter(), content, commentType, null);
+        Comment reply = new Comment(post, post.getWriter(), content, replyType, parent);
 
         System.out.println("parent = " + parent);
         System.out.println("reply = " + reply);

--- a/src/test/java/toy/board/domain/post/PostTest.java
+++ b/src/test/java/toy/board/domain/post/PostTest.java
@@ -1,21 +1,32 @@
 package toy.board.domain.post;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.jupiter.api.Assertions;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import toy.board.domain.user.MemberTest;
 import toy.board.exception.BusinessException;
 import toy.board.exception.ExceptionCode;
 
+@SpringBootTest
+@Transactional
 class PostTest {
+
+    @Autowired
+    private EntityManager em;
 
     @DisplayName("권한 없는 사용자가 게시물을 수정하려 할 경우 예외 발생")
     @Test
     public void whenUpdatePostWithNotValidWriterId_thenThrowException() throws Exception {
         //given
         Post post = create();
+        em.persist(post.getWriter());
+        em.persist(post);
         String newContent = "new";
         //when
         Long invalidWriterId = post.getWriterId() + 1;
@@ -30,6 +41,8 @@ class PostTest {
     public void whenUpdatePostWithValidWriterId_thenSuccess() throws Exception {
         //given
         Post post = create();
+        em.persist(post.getWriter());
+        em.persist(post);
         String newContent = "new";
         Long writerId = post.getWriterId();
         //when
@@ -37,8 +50,9 @@ class PostTest {
         //then
         assertThat(post.getContent()).isEqualTo(newContent);
     }
+
     public static Post create() {
-        return new Post(1L, "writer", "title", "content");
+        return new Post(MemberTest.create(), "title", "content");
     }
 
 }

--- a/src/test/java/toy/board/repository/comment/CommentRepositoryImplTest.java
+++ b/src/test/java/toy/board/repository/comment/CommentRepositoryImplTest.java
@@ -4,14 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import toy.board.repository.comment.dto.CommentDto;
 import toy.board.domain.auth.Login;
 import toy.board.domain.post.Post;
 import toy.board.domain.user.LoginType;
@@ -45,8 +42,7 @@ class CommentRepositoryImplTest {
         em.persist(member);
 
         Post post = new Post(
-                member.getId(),
-                member.getProfile().getNickname(),
+                member,
                 "title",
                 "content"
         );

--- a/src/test/java/toy/board/repository/post/PostRepositoryTest.java
+++ b/src/test/java/toy/board/repository/post/PostRepositoryTest.java
@@ -1,6 +1,6 @@
 package toy.board.repository.post;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static toy.board.domain.post.QComment.comment;
 import static toy.board.domain.post.QPost.post;
 
@@ -16,13 +16,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
-import toy.board.repository.post.dto.PostDto;
 import toy.board.domain.auth.Login;
 import toy.board.domain.post.Post;
 import toy.board.domain.user.LoginType;
 import toy.board.domain.user.Member;
 import toy.board.domain.user.Profile;
 import toy.board.domain.user.UserRole;
+import toy.board.repository.post.dto.PostDto;
 
 @SpringBootTest
 @Transactional
@@ -60,8 +60,7 @@ class PostRepositoryTest {
 
             for (int j = 0; j < postNum; j++) {
                 Post post = new Post(
-                        member.getId(),
-                        member.getProfile().getNickname(),
+                        member,
                         titlePrefix.append(j).toString(),
                         "content"
                 );

--- a/src/test/java/toy/board/repository/user/MemberRepositoryTest.java
+++ b/src/test/java/toy/board/repository/user/MemberRepositoryTest.java
@@ -1,10 +1,9 @@
 package toy.board.repository.user;
 
-import static org.assertj.core.api.Assertions.*;
-
-import java.util.Optional;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.persistence.EntityManager;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +17,6 @@ import toy.board.domain.user.LoginType;
 import toy.board.domain.user.Member;
 import toy.board.domain.user.Profile;
 import toy.board.domain.user.UserRole;
-import toy.board.repository.user.MemberRepository;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -52,7 +50,20 @@ class MemberRepositoryTest {
         em.clear();
     }
 
-    @DisplayName("닉네임으로 멤버 찾기 성공")
+    @DisplayName("memberId로 멤버 찾을 때 profile도 가져옴")
+    @Test
+    public void MemberRepositoryTest() throws  Exception {
+        //given
+
+        //when
+        Optional<Member> findMember = memberRepository.findMemberById(member.getId());
+
+        //then
+        assertThat(findMember.isPresent()).isTrue();
+        assertThat(findMember.get().getProfile()).isNotNull();
+    }
+
+    @DisplayName("닉네임으로 멤버 찾기 성공:멤버와 함께 profile도 fetch join으로 가져옴")
     @Test
     public void find_member_by_nickname_success() throws  Exception {
         // give
@@ -152,7 +163,4 @@ class MemberRepositoryTest {
         //then
         assertThat(exists).isFalse();
     }
-
-    // username으로 member 존재여부 확인 - 성공, 실패
-    // nickanme으로 member 존재여부 확인 -성공, 실패
 }

--- a/src/test/java/toy/board/service/comment/CommentServiceTest.java
+++ b/src/test/java/toy/board/service/comment/CommentServiceTest.java
@@ -40,7 +40,7 @@ class CommentServiceTest {
         em.persist(member);
         memberId = member.getId();
         nickname = member.getProfile().getNickname();
-        Post newPost = new Post(member.getId(), nickname, title, content);
+        Post newPost = new Post(member, title, content);
         em.persist(newPost);
         post = newPost;
         em.flush(); em.clear();

--- a/src/test/java/toy/board/service/post/PostServiceTest.java
+++ b/src/test/java/toy/board/service/post/PostServiceTest.java
@@ -53,7 +53,7 @@ class PostServiceTest {
     @BeforeEach
     void init() {
         Member member = MemberTest.create();
-        Post post = new Post(memberId, member.getUsername(), title, content);
+        Post post = new Post(member, title, content);
         CommentListDto commentListDto = new CommentListDto(new ArrayList<>());
 
         given(postRepository.findById(anyLong())).willReturn(Optional.empty());
@@ -78,17 +78,6 @@ class PostServiceTest {
 
         //then
         assertThat(post.getHits()).isEqualTo(expectedHits);
-    }
-
-    @DisplayName("update 성공 시 update post id 반환")
-    @Test
-    public void whenPostUpdate_thenReturnValidValue() throws  Exception {
-        //given
-        //when
-        postService.update(newContent, postId, memberId);
-        Post post = postRepository.findById(postId).get();
-        //then
-        assertThat(post.getContent()).isEqualTo(newContent);
     }
 
     @DisplayName("update 시 유효하지 않은 post id 사용하면 예외 발생")


### PR DESCRIPTION
### 주요 수정사항
- ```Comment```, ```Post```의 String writer, Long writerId를 Member writer로 통합 변경
  - ```Post```의 작성자 memberId와 작성자 닉네임 ```getter``` 구현
- 그에 따른 ```Controller```, ```Service```, ```Repository```의 변경 ```Comment```, ```Post``` 사용부분 수정
  - ```Repository```의 경우 QueryDsl 엔티티 그래프를 사용해서 쿼리 작성
- 관련 테스트 코드에 수정 부분 적용. 